### PR TITLE
feat: manage Horreum truststore with trust all opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ podman run \
   --replace --name local.perf-bot --env-file ".env" \
   --network local_default \ 
   -v /tmp/jenkins-truststore.jks:/tmp/jenkins-truststore.jks:rw,Z \ 
+  -v .certs/:/certs/:rw,Z \
   -e QUARKUS_GITHUB_APP_PRIVATE_KEY=$QUARKUS_GITHUB_APP_PRIVATE_KEY \
  -p 8081:8081 localhost/alampare/perf-bot:0.0.1-SNAPSHOT
 ```

--- a/src/main/java/io/perf/tools/bot/handler/PerfBotConfigResource.java
+++ b/src/main/java/io/perf/tools/bot/handler/PerfBotConfigResource.java
@@ -13,7 +13,6 @@ import org.jboss.resteasy.reactive.ResponseStatus;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Path("/config")
 public class PerfBotConfigResource {
@@ -39,5 +38,4 @@ public class PerfBotConfigResource {
     public List<ProjectConfig> getConfigs() {
         return new ArrayList<>(configService.getConfigs().values());
     }
-
 }

--- a/src/main/java/io/perf/tools/bot/service/datastore/horreum/Horreum.java
+++ b/src/main/java/io/perf/tools/bot/service/datastore/horreum/Horreum.java
@@ -1,0 +1,74 @@
+package io.perf.tools.bot.service.datastore.horreum;
+
+import io.quarkus.logging.Log;
+import io.quarkus.runtime.Startup;
+import jakarta.enterprise.inject.Default;
+import jakarta.ws.rs.Produces;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+@Startup
+public class Horreum {
+
+    static TrustManager[] trustAllCerts = new TrustManager[] {
+            new X509TrustManager() {
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            }
+    };
+
+    @ConfigProperty(name = "proxy.datastore.horreum.truststore.trust-all")
+    Boolean useTrustAllCerts;
+
+    @ConfigProperty(name = "proxy.datastore.horreum.truststore.file")
+    String trustStoreFile;
+
+    @ConfigProperty(name = "proxy.datastore.horreum.truststore.pwd")
+    String trustStorePwd;
+
+    @Produces
+    @Default
+    public SSLContext horreumSslContext() {
+        SSLContext sc = null;
+        try {
+            if (useTrustAllCerts) {
+                sc = SSLContext.getInstance("TLS");
+                sc.init(null, trustAllCerts, new SecureRandom());
+
+                SSLContext.setDefault(sc);
+            } else if (trustStoreFile != null && !trustStoreFile.isBlank()) {
+                KeyStore trustStore = KeyStore.getInstance("JKS");
+                trustStore.load(new FileInputStream(trustStoreFile), trustStorePwd.toCharArray());
+
+                // Create SSLContext from truststore
+                sc = SSLContextBuilder.create()
+                        .loadTrustMaterial(trustStore, null)
+                        .build();
+            }
+        } catch (NoSuchAlgorithmException | KeyManagementException | KeyStoreException | IOException | CertificateException e) {
+            Log.error("Error initializing SSL context", e);
+            throw new RuntimeException("Error initializing SSL context");
+        }
+        return sc;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,12 +8,15 @@ perf.bot.prompt=/perf-bot
 
 # Horreum proxy
 proxy.datastore.horreum.url=http://local.horreum-app:8080
+proxy.datastore.horreum.truststore.trust-all=true
+proxy.datastore.horreum.truststore.file=/certs/horreum-truststore.jks
+proxy.datastore.horreum.truststore.pwd=changeit
 
 # Jenkins proxy
 proxy.job.runner.jenkins.url=http://local.jenkins:8080
 proxy.job.runner.jenkins.user=admin
 proxy.job.runner.jenkins.apiKey=11c513a545425a50c202367deefad6ed33
-proxy.job.runner.jenkins.truststore.file=/tmp/jenkins-truststore.jks
+proxy.job.runner.jenkins.truststore.file=/certs/jenkins-truststore.jks
 proxy.job.runner.jenkins.truststore.pwd=changeit
 
 # AMQP endpoint


### PR DESCRIPTION
Added Horreum truststore management, including `proxy.datastore.horreum.truststore.trust-all` option.