### PR TITLE
feat: implement additional checks

### DIFF
--- a/scripts/assets/repo-config.json
+++ b/scripts/assets/repo-config.json
@@ -18,7 +18,9 @@
           "name": "PULL_REQUEST_NUMBER",
           "defaultValue": "1"
         }
-      }
+      },
+      "pullRequestNumberParam": "PULL_REQUEST_NUMBER",
+      "repoCommitParam": "APP_COMMIT"
     }
   }
 }

--- a/src/main/java/io/perf/tools/bot/action/impl/Run.java
+++ b/src/main/java/io/perf/tools/bot/action/impl/Run.java
@@ -37,6 +37,15 @@ public class Run extends BaseAction {
         Map<String, String> params = new HashMap<>();
         Matcher matcher = pattern.matcher(context.getPayload().getComment().getBody());
 
+        if (job.pullRequestNumberParam != null && !job.pullRequestNumberParam.isBlank()) {
+            params.put(job.pullRequestNumberParam, Integer.toString(context.getIssue().getNumber()));
+        }
+
+        if (job.repoCommitParam != null && !job.repoCommitParam.isBlank()) {
+            // TODO: find a way to fetch current commit of the PR
+            params.put(job.repoCommitParam, "");
+        }
+
         while (matcher.find()) {
             String key = matcher.group(1);
             String rawValue = matcher.group(2);

--- a/src/main/java/io/perf/tools/bot/action/impl/Validate.java
+++ b/src/main/java/io/perf/tools/bot/action/impl/Validate.java
@@ -29,6 +29,11 @@ public class Validate extends BaseAction {
             return;
         }
 
+        if (!context.getIssue().isPullRequest()) {
+            context.setCurrentResult(ActionResult.failure("Sorry! I can only run performance tests on PRs", getName()));
+            return;
+        }
+
         String login = context.getIssue().getUser().getLogin();
         if (context.getProjectConfig().authorizedUsers.contains(login)) {
             context.setCurrentResult(ActionResult.success("User " + login + " authorized", getName()));

--- a/src/main/java/io/perf/tools/bot/model/JobDef.java
+++ b/src/main/java/io/perf/tools/bot/model/JobDef.java
@@ -8,5 +8,8 @@ public class JobDef {
     public String user;
     public String jenkinsJob;
 
+    public String pullRequestNumberParam;
+    public String repoCommitParam;
+
     public Map<String, Param> configurableParams;
 }

--- a/src/main/java/io/perf/tools/bot/service/PullRequestService.java
+++ b/src/main/java/io/perf/tools/bot/service/PullRequestService.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 @ApplicationScoped
 public class PullRequestService {
 
+    public static final String ISSUE_COMMENT_CREATE_ACTION = "created";
+
     @Inject
     ActionResolver actionResolver;
 
@@ -33,7 +35,8 @@ public class PullRequestService {
     public void onGithubComment(GHEventPayload.IssueComment issueComment) throws IOException {
         Action action = actionResolver.getActionFromComment(issueComment.getComment().getBody());
         ProjectConfig config = configService.getConfig(PayloadHelper.getRepository(issueComment).getFullName());
-        if (action != null) {
+        // skip any issue comment action that is not "created", e.g., ignore comment deletion
+        if (action != null && ISSUE_COMMENT_CREATE_ACTION.equalsIgnoreCase(issueComment.getAction())) {
             ActionContext ctx = new ActionContext(issueComment, config)
                     .process(validateAction)
                     .process(action)


### PR DESCRIPTION
implement additional event checks
* skip events that are not "created"
* only PRs are supported

make expected params configurable through the repo config:
* repo commit
* pull request number

so that the perf-bot can automatically fetch and populate them.

> repo commit is currently not populated because the information is not present in the event - need further processing