### PR TITLE
dev: automate local env setup for dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,82 @@ development and CI, and reduce late-stage surprises or production issues.
 Check out the [architecture docs](docs/architecture/index.md) for more information on the Perf Bot internals and 
 the supported workflows.
 
+## Providers
+
+Currently, the `Perf Bot` supports 2 different source of events:
+
+* `GitHubEventHandler`, the default [GitHub Handler](src/main/java/io/perf/tools/bot/handler/event/GitHubEventHandler.java)
+   as defined by the [Quarkus GitHub Framework](https://docs.quarkiverse.io/quarkus-github-app/dev/create-github-app.html).
+* `AmqpEventHandler`, a custom [AMQP handler](src/main/java/io/perf/tools/bot/handler/event/AmqpEventHandler.java) that
+   consumes events from a configured AMQP channel.
+
+Required configuration:
+
+```dotenv
+# GitHub app configuration
+QUARKUS_GITHUB_APP_APP_ID=<the numeric app id>
+QUARKUS_GITHUB_APP_APP_NAME=<the name of your app>
+QUARKUS_GITHUB_APP_WEBHOOK_PROXY_URL=<your Smee.io channel URL>
+QUARKUS_GITHUB_APP_WEBHOOK_SECRET=<your webhook secret>
+QUARKUS_GITHUB_APP_PRIVATE_KEY=-----BEGIN RSA PRIVATE KEY-----\
+                  <your private key>                          \
+-----END RSA PRIVATE KEY-----
+
+# AMQP configuration
+AMQP_HOST=<amqp host>
+AMQP_PORT=5671
+AMQP_USERNAME=<amqp username>
+AMQP_PASSWORD=<amqp password>
+```
+
+> [!NOTE]
+> If you are running in production or using a Webhook proxy other than smee.io, you don't
+> need `QUARKUS_GITHUB_APP_WEBHOOK_PROXY_URL` env variable.
+
 ## Commands
 
-Here a list of the supported commands
+Here a list of the supported commands:
+
+TODO
 
 ## AMQP Bridge
 
-If you are running behind some private network, and you cannot consume webhook events directly from GitHub, you 
-might be interested in setting up an intermediate _bridge_ that will fetch those events and forward them into a 
-message broker, e.g., ActiveMQ.
+If you're operating within a private network and cannot receive webhook events directly from GitHub, you may want to 
+set up an intermediate *bridge* to fetch those events and forward them to a message broker such as ActiveMQ.
 
-For this purpose, we implemented a new handler that will consume the GitHub events from a pre-configured queue.
+To support this scenario, we've implemented a handler that consumes GitHub events from a pre-configured queue 
+(see [providers](#providers) section).
 
-You will need additional configuration in this case:
+You'll need to provide the following configuration:
 
-* `AMQP_HOST`: The hostname of the AMQP broker
-* `AMQP_PORT`: The port of the AMQP broker
-* `AMQP_USERNAME`: Service account username of the Perf Bot 
-* `AMQP_PASSWORD`: Service account password of the Perf Bot
+- `AMQP_HOST`: Hostname of the AMQP broker
+- `AMQP_PORT`: Port of the AMQP broker
+- `AMQP_USERNAME`: Service account username for the Perf Bot
+- `AMQP_PASSWORD`: Service account password for the Perf Bot
 
-Additionally, you may need the service account certificates. Save those as
-`.certs/service-account.key`, `.certs/service-account.crt` and `.certs/ca.crt` respectively.
+If running with `prod` profile, you may also need service account certificates, saved in the following paths:
 
-Most likely the key is encrypted  with a password, which is not supported by Vert.x at the moment. 
-It can be decrypted with the command `openssl rsa -in service-account.key -out service-account-unencrypted.key`.
+- `/tmp/certs/service-account.key`
+- `/tmp/certs/service-account.crt`
+- `/tmp/certs/ca.crt`
+
+> [!NOTE] 
+> The private key is likely encrypted with a password, which Vert.x does not currently support.  
+> To work around this, you can decrypt the key using the following command:
+>```bash
+>openssl rsa -in service-account.key -out service-account-unencrypted.key
+>```
 
 ## Local environment
 
 For all the local environment credentials that are used to interact with the environment itself, 
 please refer to the [credentials](#credentials) section.
+
+> [!IMPORTANT]  
+> The local environment setup has been automated as part of quarkus development startup, i.e., running 
+> `mvn quarkus:dev` will start up the local env automatically. You can disable this behavior by adding 
+> `-Dquarkus.compose.devservices.enabled=false`
+
 
 ### Prerequisites
 
@@ -63,7 +110,7 @@ mvn clean install -DskipTests -DskipITs -Dquarkus.container-image.build=true
 podman run \
   --replace --name local.perf-bot --env-file ".env" \
   --network local_default \ 
-  -v .certs/:/certs/:rw,Z \
+  -v /tmp/certs/:/tmp/certs/:rw,Z \
   -e QUARKUS_GITHUB_APP_PRIVATE_KEY=$QUARKUS_GITHUB_APP_PRIVATE_KEY \
  -p 8081:8081 localhost/alampare/perf-bot:0.0.1-SNAPSHOT
 ```

--- a/deploy/compose-devservices.yml
+++ b/deploy/compose-devservices.yml
@@ -5,6 +5,8 @@ services:
     container_name: local.jenkins
     labels:
       env: "local"
+      # used by quarkus dev-service to check system up
+      io.quarkus.devservices.compose.wait_for.logs: .*Jenkins seems to be UP.*
     build:
       # We must pass whole current dir as context to map ssh folder
       dockerfile: jenkins/Containerfile
@@ -18,6 +20,12 @@ services:
       - "./ssh:/var/jenkins_home/.ssh:ro${SE_LINUX_SUFFIX:-,Z}"
     security_opt:
       - "label=disable"
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080;echo -e \"GET /health/ HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]
+      interval: 2s
+      retries: 5
+      start_period: 10s
+      timeout: 20s
 
   postgres:
     image: mirror.gcr.io/library/postgres:16
@@ -49,6 +57,8 @@ services:
     container_name: local.horreum-amq
     labels:
       env: "local"
+      # used by quarkus dev-service to check system up
+      io.quarkus.devservices.compose.wait_for.logs: .*HTTP Server started at.*
     networks:
       - local_default
     environment:
@@ -60,6 +70,13 @@ services:
       - "15672:5672"
     volumes:
       - ./horreum/broker.xml:/opt/amq/conf/broker.xml:Z
+    healthcheck:
+      # BROKER_IP is internally computed using `hostname -I | cut -f 1 -d ' '`
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/$(hostname -I | cut -f 1 -d ' ')/8161;echo -e \"GET /console/ HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 302 Found\" <&3"]
+      interval: 2s
+      retries: 5
+      start_period: 10s
+      timeout: 20s
 
   keycloak:
     image: quay.io/keycloak/keycloak:23.0.3
@@ -93,6 +110,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+        required: true
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8180;echo -e \"GET /health/ready HTTP/1.1\r\nhost: http://localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]
       interval: 2s
@@ -105,6 +123,8 @@ services:
     container_name: local.horreum-app
     labels:
       env: "local"
+      # used by quarkus dev-service to check system up
+      io.quarkus.devservices.compose.wait_for.logs: .*Listening on.*
     networks:
       - local_default
     environment:
@@ -142,7 +162,8 @@ services:
         condition: service_healthy
         required: true
       amqp:
-        condition: service_started
+        condition: service_healthy
+        required: true
 
 # Use existing scripts to populate the Horreum and print the generate Horreum API key
   init:

--- a/deploy/horreum/broker.xml
+++ b/deploy/horreum/broker.xml
@@ -180,6 +180,16 @@
                     <queue name="run-recalc"/>
                 </anycast>
             </address>
+            <address name="schema-sync">
+                <anycast>
+                    <queue name="schema-sync"/>
+                </anycast>
+            </address>
+            <address name="run-upload">
+                <anycast>
+                    <queue name="run-upload"/>
+                </anycast>
+            </address>
         </addresses>
     </core>
 </configuration>

--- a/deploy/start.sh
+++ b/deploy/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-podman-compose up --build
+podman-compose -f compose-devservices.yml up --build

--- a/deploy/stop.sh
+++ b/deploy/stop.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-podman-compose down 
+podman-compose -f compose-devservices.yml down 
 # podman volume rm deploy_local_horreum_db

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <surefire-plugin.version>3.3.1</surefire-plugin.version>
 
         <!-- dependencies versions -->
-        <quarkus.platform.version>3.21.3</quarkus.platform.version>
+        <quarkus.platform.version>3.22.3</quarkus.platform.version>
         <quarkus.github.app.version>2.8.5</quarkus.github.app.version>
         <jenkins.client.version>0.3.8</jenkins.client.version>
         <!-- locally built from https://github.com/Hyperfoil/Horreum/tree/master -->

--- a/src/main/java/io/perf/tools/bot/handler/ConfigResource.java
+++ b/src/main/java/io/perf/tools/bot/handler/ConfigResource.java
@@ -31,7 +31,7 @@ import java.util.List;
  * @see ProjectConfig
  */
 @Path("/config")
-public class PerfBotConfigResource {
+public class ConfigResource {
 
     @Inject
     ConfigService configService;

--- a/src/main/java/io/perf/tools/bot/handler/HorreumResource.java
+++ b/src/main/java/io/perf/tools/bot/handler/HorreumResource.java
@@ -26,7 +26,7 @@ import java.io.IOException;
  * </p>
  */
 @Path("/horreum")
-public class HorreumWebhookResource {
+public class HorreumResource {
 
     private static final String REPO_FULL_NAME_LABEL_VALUE = "pb.repo_full_name";
     private static final String PULL_REQUEST_NUMBER_LABEL_VALUE = "pb.pull_request_number";

--- a/src/main/java/io/perf/tools/bot/handler/event/GitHubEventHandler.java
+++ b/src/main/java/io/perf/tools/bot/handler/event/GitHubEventHandler.java
@@ -1,4 +1,4 @@
-package io.perf.tools.bot.handler;
+package io.perf.tools.bot.handler.event;
 
 import io.perf.tools.bot.service.PerfBotService;
 import io.quarkiverse.githubapp.event.IssueComment;
@@ -18,7 +18,7 @@ import org.kohsuke.github.GHEventPayload;
  * @see PerfBotService
  * @see GHEventPayload.IssueComment
  */
-public class GithubEventHandler {
+public class GitHubEventHandler {
 
     @Inject
     PerfBotService perfBotService;

--- a/src/main/java/io/perf/tools/bot/service/datastore/horreum/Horreum.java
+++ b/src/main/java/io/perf/tools/bot/service/datastore/horreum/Horreum.java
@@ -3,8 +3,6 @@ package io.perf.tools.bot.service.datastore.horreum;
 import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
 import io.smallrye.common.annotation.Identifier;
-import jakarta.enterprise.inject.Default;
-import jakarta.inject.Named;
 import jakarta.ws.rs.Produces;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -21,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 
 @Startup
 public class Horreum {
@@ -42,11 +41,11 @@ public class Horreum {
     @ConfigProperty(name = "proxy.datastore.horreum.truststore.trust-all")
     Boolean useTrustAllCerts;
 
-    @ConfigProperty(name = "proxy.datastore.horreum.truststore.file")
-    String trustStoreFile;
+    @ConfigProperty(name = "proxy.datastore.horreum.truststore.file", defaultValue = "")
+    Optional<String> trustStoreFile;
 
     @ConfigProperty(name = "proxy.datastore.horreum.truststore.pwd")
-    String trustStorePwd;
+    Optional<String> trustStorePwd;
 
     @Produces
     @Identifier("horreumSslContext")
@@ -58,9 +57,9 @@ public class Horreum {
                 sc.init(null, trustAllCerts, new SecureRandom());
 
                 SSLContext.setDefault(sc);
-            } else if (trustStoreFile != null && !trustStoreFile.isBlank()) {
+            } else if (trustStoreFile.isPresent() && !trustStoreFile.get().isBlank()) {
                 KeyStore trustStore = KeyStore.getInstance("JKS");
-                trustStore.load(new FileInputStream(trustStoreFile), trustStorePwd.toCharArray());
+                trustStore.load(new FileInputStream(trustStoreFile.get()), trustStorePwd.orElse("").toCharArray());
 
                 // Create SSLContext from truststore
                 sc = SSLContextBuilder.create()

--- a/src/main/java/io/perf/tools/bot/service/job/jenkins/Jenkins.java
+++ b/src/main/java/io/perf/tools/bot/service/job/jenkins/Jenkins.java
@@ -20,6 +20,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.util.Optional;
 
 @Startup
 public class Jenkins {
@@ -34,10 +35,10 @@ public class Jenkins {
     String apiKey;
 
     @ConfigProperty(name = "proxy.job.runner.jenkins.truststore.file")
-    String truststore;
+    Optional<String> trustStoreFile;
 
     @ConfigProperty(name = "proxy.job.runner.jenkins.truststore.pwd")
-    String truststorePwd;
+    Optional<String> trustStorePwd;
 
     @Produces
     public JenkinsServer jenkinsServer()
@@ -49,13 +50,15 @@ public class Jenkins {
         }
         URI uri = new URI(url);
 
-        KeyStore trustStore = KeyStore.getInstance("JKS");
-        trustStore.load(new FileInputStream(truststore), truststorePwd.toCharArray());
+        SSLContextBuilder sslContextBuilder = SSLContextBuilder.create();
 
-        // Create SSLContext from truststore
-        SSLContext sslContext = SSLContextBuilder.create()
-                .loadTrustMaterial(trustStore, null)
-                .build();
+        if (trustStoreFile.isPresent() && !trustStoreFile.get().isBlank()) {
+            KeyStore trustStore = KeyStore.getInstance("JKS");
+            trustStore.load(new FileInputStream(trustStoreFile.get()), trustStorePwd.orElse("").toCharArray());
+            sslContextBuilder.loadTrustMaterial(trustStore, null);
+        }
+
+        SSLContext sslContext = sslContextBuilder.build();
 
         // Create a custom HttpClient builder with the SSL context
         SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext);

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,23 @@
+# Additional properties required for AMQP profile
+#quarkus.config.profile.parent=common
+
+# AMQP endpoint
+mp.messaging.incoming.amqp-channel.address=Consumer.app-svc-perf.perf-bot-app.VirtualTopic.external.github.lampajr.webhook-umb-example
+mp.messaging.incoming.amqp-channel.use-ssl=true
+mp.messaging.incoming.amqp-channel.tls-configuration-name=amqp
+
+quarkus.tls.amqp.trust-store.pem.certs=/tmp/certs/ca.crt
+quarkus.tls.amqp.key-store.pem.prod.key=/tmp/certs/service-account-unencrypted.key
+quarkus.tls.amqp.key-store.pem.prod.cert=/tmp/certs/service-account.crt
+
+# Horreum
+proxy.datastore.horreum.truststore.file=/tmp/certs/horreum-truststore.jks
+proxy.datastore.horreum.truststore.pwd=changeit
+
+# Jenkins
+proxy.job.runner.jenkins.truststore.file=/tmp/certs/jenkins-truststore.jks
+proxy.job.runner.jenkins.truststore.pwd=changeit
+
+# Dev services
+quarkus.amqp.devservices.enabled=false
+quarkus.compose.devservices.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,29 +3,23 @@ quarkus.log.level=INFO
 
 # GitHub app installation id
 perf.bot.installation.id=67481108
-
 perf.bot.prompt=/perf-bot
+
+# AMQP source
+mp.messaging.incoming.amqp-channel.address=amqp-dev-channel
+mp.messaging.incoming.amqp-channel.connector=smallrye-amqp
+mp.messaging.incoming.amqp-channel.failure-strategy=reject
 
 # Horreum proxy
 proxy.datastore.horreum.url=http://local.horreum-app:8080
 proxy.datastore.horreum.truststore.trust-all=true
-proxy.datastore.horreum.truststore.file=/certs/horreum-truststore.jks
-proxy.datastore.horreum.truststore.pwd=changeit
 
 # Jenkins proxy
 proxy.job.runner.jenkins.url=http://local.jenkins:8080
 proxy.job.runner.jenkins.user=admin
 proxy.job.runner.jenkins.apiKey=11c513a545425a50c202367deefad6ed33
-proxy.job.runner.jenkins.truststore.file=/certs/jenkins-truststore.jks
-proxy.job.runner.jenkins.truststore.pwd=changeit
 
-# AMQP endpoint
-mp.messaging.incoming."Consumer.app-svc-perf.perf-bot-app.VirtualTopic.external.github.lampajr.webhook-umb-example".connector=smallrye-amqp
-mp.messaging.incoming."Consumer.app-svc-perf.perf-bot-app.VirtualTopic.external.github.lampajr.webhook-umb-example".use-ssl=true
-mp.messaging.incoming."Consumer.app-svc-perf.perf-bot-app.VirtualTopic.external.github.lampajr.webhook-umb-example".tls-configuration-name=amqp
-mp.messaging.incoming."Consumer.app-svc-perf.perf-bot-app.VirtualTopic.external.github.lampajr.webhook-umb-example".failure-strategy=reject
-
-# TLS
-quarkus.tls.amqp.trust-store.pem.certs=/certs/ca.crt
-quarkus.tls.amqp.key-store.pem.prod.key=/certs/service-account-unencrypted.key
-quarkus.tls.amqp.key-store.pem.prod.cert=/certs/service-account.crt
+# Dev services
+quarkus.amqp.devservices.enabled=true
+quarkus.compose.devservices.enabled=true
+quarkus.compose.devservices.files=deploy/compose-devservices.yml


### PR DESCRIPTION
- [x] Automated the local env startup as part of the Quarkus dev-sevices.

Now simply running `mvn quarkus:dev` will startup the entire local env (jenkins, postgres, amqp, keycloak and horreum).
You can disable this by adding `-Dquarkus.compose.devservices.enabled=false`.

- [x] Renamed UMB to a generic `AMQP` as we are not restricted to that
- [x] Removed the hard-coded topic from the source code and moved it in the `application-prod.properties`